### PR TITLE
[Fix] Modified correct FileExtension

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,6 +8,6 @@ define(function (require, exports, module) {
 
     var language = LanguageManager.getLanguage("php");
     
-    language.addFileExtension("silverstripe.ss");
+    language.addFileExtension(".ss");
     language.setBlockCommentSyntax("<%--", "--%>");
 });


### PR DESCRIPTION
Changed FileExtension from 'silverstripe.ss' to '.ss' to actually make the plug-in work
Fixes Maldicore/brackets-silverstripe#1
